### PR TITLE
Fix carriage return being counted as part of tokens

### DIFF
--- a/GDWeave.Sample/util/ScriptTokenizer.cs
+++ b/GDWeave.Sample/util/ScriptTokenizer.cs
@@ -384,6 +384,11 @@ public static class ScriptTokenizer
 				continue;
 			}
 
+            if (text[i] == '\r')
+            {
+                continue;
+            }
+
 			// This is stupid and awful
 			if (text[i] == '\n')
 			{


### PR DESCRIPTION
When Windows line endings `\r\n` where in use the carriage return was being considered part of tokens 